### PR TITLE
Add composer v2 compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,16 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  phpunit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: php-actions/composer@v6
+        with:
+          php_version: '8.1'
+          command: install --ignore-platform-req=ext-dom --ignore-platform-req=ext-xml --ignore-platform-req=ext-xmlwriter
+      - run: vendor/bin/phpunit

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 composer.phar
 /vendor/
 .php_cs.cache
+/.phpunit.result.cache
 composer.lock
 .idea

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ComposerSymlinks
 =====================
 
-Its provide a simple Composer script to symlink paths.
+Its provide a simple Composer script to symlink paths. Compatible with Composer v2.
 
 Installation
 ------------

--- a/composer.json
+++ b/composer.json
@@ -19,15 +19,24 @@
       "SomeWork\\": "src/"
     }
   },
+  "autoload-dev": {
+    "psr-4": {
+      "SomeWork\\Symlinks\\Tests\\": "tests/"
+    }
+  },
   "extra": {
     "class": "SomeWork\\Symlinks\\Plugin"
   },
   "require": {
-    "php": ">7.0",
-    "composer-plugin-api": "^1.0"
+    "php": ">=8.0",
+    "composer-plugin-api": "^2.0"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "@stable",
-    "composer/composer": "^1.0"
+    "composer/composer": "^2.0",
+    "phpunit/phpunit": "^9"
+  },
+  "scripts": {
+    "test": "phpunit"
   }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php">
+    <testsuites>
+        <testsuite name="unit">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Symlinks/Plugin.php
+++ b/src/Symlinks/Plugin.php
@@ -22,11 +22,19 @@ class Plugin implements PluginInterface
      * @param Composer    $composer
      * @param IOInterface $io
      */
-    public function activate(Composer $composer, IOInterface $io)
+    public function activate(Composer $composer, IOInterface $io): void
     {
         $eventDispatcher = $composer->getEventDispatcher();
         $eventDispatcher->addListener(ScriptEvents::POST_INSTALL_CMD, $this->createLinks());
         $eventDispatcher->addListener(ScriptEvents::POST_UPDATE_CMD, $this->createLinks());
+    }
+
+    public function deactivate(Composer $composer, IOInterface $io): void
+    {
+    }
+
+    public function uninstall(Composer $composer, IOInterface $io): void
+    {
     }
 
     /**

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace SomeWork\Symlinks\Tests;
+
+use Composer\Composer;
+use Composer\EventDispatcher\EventDispatcher;
+use Composer\IO\NullIO;
+use Composer\Script\ScriptEvents;
+use PHPUnit\Framework\TestCase;
+use SomeWork\Symlinks\Plugin;
+
+class PluginTest extends TestCase
+{
+    public function testActivateRegistersListeners(): void
+    {
+        $composer = new Composer();
+        $dispatcher = new class($composer) extends EventDispatcher {
+            public $recorded = [];
+            public function __construct(Composer $composer)
+            {
+                parent::__construct($composer, new NullIO());
+            }
+            public function addListener(string $eventName, $listener, int $priority = 0): void
+            {
+                $this->recorded[$eventName][] = $listener;
+                parent::addListener($eventName, $listener, $priority);
+            }
+        };
+        $composer->setEventDispatcher($dispatcher);
+
+        $plugin = new Plugin();
+        $plugin->activate($composer, new NullIO());
+
+        $this->assertArrayHasKey(ScriptEvents::POST_INSTALL_CMD, $dispatcher->recorded);
+        $this->assertArrayHasKey(ScriptEvents::POST_UPDATE_CMD, $dispatcher->recorded);
+        $this->assertIsCallable($dispatcher->recorded[ScriptEvents::POST_INSTALL_CMD][0]);
+    }
+}

--- a/tests/SymlinksFactoryTest.php
+++ b/tests/SymlinksFactoryTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace SomeWork\Symlinks\Tests;
+
+use Composer\Composer;
+use Composer\EventDispatcher\EventDispatcher;
+use Composer\IO\NullIO;
+use Composer\Package\RootPackage;
+use Composer\Script\Event;
+use PHPUnit\Framework\TestCase;
+use Composer\Util\Filesystem;
+use SomeWork\Symlinks\SymlinksFactory;
+
+class SymlinksFactoryTest extends TestCase
+{
+    public function testProcessCreatesSymlinkDefinition(): void
+    {
+        $tmp = sys_get_temp_dir() . '/factory_' . uniqid();
+        mkdir($tmp);
+        mkdir($tmp . '/target');
+        file_put_contents($tmp . '/target/file.txt', 'content');
+        $cwd = getcwd();
+        chdir($tmp);
+
+        $composer = new Composer();
+        $dispatcher = new EventDispatcher($composer, new NullIO());
+        $composer->setEventDispatcher($dispatcher);
+        $package = new RootPackage('test/test', '1.0.0', '1.0.0');
+        $package->setExtra([
+            'somework/composer-symlinks' => [
+                'symlinks' => [
+                    'target/file.txt' => 'link.txt'
+                ],
+                'absolute-path' => true
+            ]
+        ]);
+        $composer->setPackage($package);
+
+        $event = new Event('post-install-cmd', $composer, new NullIO());
+        $factory = new SymlinksFactory($event, new Filesystem());
+        $symlinks = $factory->process();
+
+        $this->assertCount(1, $symlinks);
+        $symlink = $symlinks[0];
+        $this->assertSame(realpath($tmp . '/target/file.txt'), $symlink->getTarget());
+        $this->assertSame($tmp . '/link.txt', $symlink->getLink());
+        $this->assertTrue($symlink->isAbsolutePath());
+
+        chdir($cwd);
+    }
+}

--- a/tests/SymlinksProcessorTest.php
+++ b/tests/SymlinksProcessorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace SomeWork\Symlinks\Tests;
+
+use Composer\Util\Filesystem;
+use PHPUnit\Framework\TestCase;
+use SomeWork\Symlinks\Symlink;
+use SomeWork\Symlinks\SymlinksProcessor;
+
+class SymlinksProcessorTest extends TestCase
+{
+    public function testProcessSymlinkCreatesLink(): void
+    {
+        $tmp = sys_get_temp_dir() . '/processor_' . uniqid();
+        mkdir($tmp);
+        $target = $tmp . '/target.txt';
+        file_put_contents($target, 'data');
+
+        $link = $tmp . '/link.txt';
+
+        $symlink = (new Symlink())
+            ->setTarget($target)
+            ->setLink($link)
+            ->setAbsolutePath(true);
+
+        $processor = new SymlinksProcessor(new Filesystem());
+        $result = $processor->processSymlink($symlink);
+
+        $this->assertTrue($result);
+        $this->assertTrue(is_link($link));
+        $this->assertSame(realpath($target), realpath(readlink($link)));
+    }
+}


### PR DESCRIPTION
## Summary
- update composer requirements for Composer v2 and PHP 8+
- add PHPUnit tests
- configure GitHub Actions to run tests
- document Composer v2 compatibility only

## Testing
- `composer validate --strict`
- `find src tests -name '*.php' -print0 | xargs -0 -n1 php -l`
- `vendor/bin/phpunit --configuration phpunit.xml` *(after installing deps with `composer update` and installing PHP XML extensions)*

------
https://chatgpt.com/codex/tasks/task_e_684421413fe8832098567ec6c2883c4e