### PR TITLE
Enable PHP7.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: ["8.0", "8.1"]
+        php-version: ["7.4", "8.0", "8.1", "8.2"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up PHP

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "class": "SomeWork\\Symlinks\\Plugin"
   },
   "require": {
-    "php": ">=8.0",
+    "php": ">=7.4",
     "composer-plugin-api": "^2.0"
   },
   "require-dev": {

--- a/tests/ComposerIntegrationTest.php
+++ b/tests/ComposerIntegrationTest.php
@@ -74,7 +74,7 @@ class ComposerIntegrationTest extends TestCase
             realpath($tmp . '/sourceA/fileA.txt'),
             realpath($tmp . '/' . readlink($tmp . '/linkA.txt'))
         );
-        $this->assertFalse(str_starts_with(readlink($tmp . '/linkA.txt'), '/'));
+        $this->assertNotSame('/', substr(readlink($tmp . '/linkA.txt'), 0, 1));
 
         $this->assertTrue(is_link($tmp . '/linkB.txt'));
         $this->assertSame(


### PR DESCRIPTION
## Summary
- widen Composer package PHP requirement to `>=7.4`
- update integration test for PHP 7.4 compatibility
- test GitHub workflow across PHP 7.4–8.2

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6844476589f88320bcd9ea94daa0d08a