### PR TITLE
Add invalid symlinks type test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,11 @@ name: CI
 
 on:
   push:
+    branches:
+      - master
   pull_request:
+    branches:
+      - master
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Run PHPUnit
         run: vendor/bin/phpunit --coverage-clover=coverage.xml
       - name: Upload coverage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-${{ matrix.php-version }}
           path: coverage.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
-          coverage: none
+          coverage: xdebug
       - name: Cache Composer dependencies
         uses: actions/cache@v3
         with:
@@ -29,4 +29,9 @@ jobs:
       - name: Run PHP CS Fixer
         run: vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php --dry-run --diff --allow-risky=yes
       - name: Run PHPUnit
-        run: vendor/bin/phpunit
+        run: vendor/bin/phpunit --coverage-clover=coverage.xml
+      - name: Upload coverage
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-${{ matrix.php-version }}
+          path: coverage.xml

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ composer.phar
 /.phpunit.result.cache
 composer.lock
 .idea
+coverage.xml

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit bootstrap="vendor/autoload.php">
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </coverage>
     <testsuites>
         <testsuite name="unit">
             <directory>tests</directory>

--- a/tests/SymlinksFactoryTest.php
+++ b/tests/SymlinksFactoryTest.php
@@ -205,4 +205,179 @@ class SymlinksFactoryTest extends TestCase
         $this->expectExceptionMessage('Invalid symlink link path');
         $factory->process();
     }
+
+    public function testProcessThrowsExceptionWhenSymlinksIsNotArray(): void
+    {
+        $composer = new Composer();
+        $dispatcher = new EventDispatcher($composer, new NullIO());
+        $composer->setEventDispatcher($dispatcher);
+        $package = new RootPackage('test/test', '1.0.0', '1.0.0');
+        $package->setExtra([
+            'somework/composer-symlinks' => [
+                'symlinks' => 'invalid'
+            ]
+        ]);
+        $composer->setPackage($package);
+
+        $event = new Event('post-install-cmd', $composer, new NullIO());
+        $factory = new SymlinksFactory($event, new Filesystem());
+
+        $this->expectException(\SomeWork\Symlinks\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The extra.somework/composer-symlinks.symlinks setting must be an array.');
+        $factory->process();
+    }
+
+    public function testProcessReturnsEmptyWhenNoSymlinksConfigured(): void
+    {
+        $composer = new Composer();
+        $dispatcher = new EventDispatcher($composer, new NullIO());
+        $composer->setEventDispatcher($dispatcher);
+        $package = new RootPackage('test/test', '1.0.0', '1.0.0');
+        $package->setExtra([]);
+        $composer->setPackage($package);
+
+        $event = new Event('post-install-cmd', $composer, new NullIO());
+        $factory = new SymlinksFactory($event, new Filesystem());
+        $symlinks = $factory->process();
+
+        $this->assertSame([], $symlinks);
+    }
+
+    public function testProcessSkipsMissingTargetGlobally(): void
+    {
+        $tmp = sys_get_temp_dir() . '/factory_' . uniqid();
+        mkdir($tmp);
+        $cwd = getcwd();
+        chdir($tmp);
+
+        $composer = new Composer();
+        $dispatcher = new EventDispatcher($composer, new NullIO());
+        $composer->setEventDispatcher($dispatcher);
+        $package = new RootPackage('test/test', '1.0.0', '1.0.0');
+        $package->setExtra([
+            'somework/composer-symlinks' => [
+                'symlinks' => [
+                    'missing/file.txt' => 'link.txt'
+                ],
+                'skip-missing-target' => true
+            ]
+        ]);
+        $composer->setPackage($package);
+
+        $event = new Event('post-install-cmd', $composer, new NullIO());
+        $factory = new SymlinksFactory($event, new Filesystem());
+        $symlinks = $factory->process();
+
+        $this->assertCount(0, $symlinks);
+
+        chdir($cwd);
+    }
+
+    public function testProcessSetsForceCreateFromConfig(): void
+    {
+        $tmp = sys_get_temp_dir() . '/factory_' . uniqid();
+        mkdir($tmp);
+        mkdir($tmp . '/target');
+        file_put_contents($tmp . '/target/file.txt', 'content');
+        $cwd = getcwd();
+        chdir($tmp);
+
+        $composer = new Composer();
+        $dispatcher = new EventDispatcher($composer, new NullIO());
+        $composer->setEventDispatcher($dispatcher);
+        $package = new RootPackage('test/test', '1.0.0', '1.0.0');
+        $package->setExtra([
+            'somework/composer-symlinks' => [
+                'symlinks' => [
+                    'target/file.txt' => 'link.txt'
+                ],
+                'force-create' => true
+            ]
+        ]);
+        $composer->setPackage($package);
+
+        $event = new Event('post-install-cmd', $composer, new NullIO());
+        $factory = new SymlinksFactory($event, new Filesystem());
+        $symlinks = $factory->process();
+
+        $this->assertCount(1, $symlinks);
+        $this->assertTrue($symlinks[0]->isForceCreate());
+
+        chdir($cwd);
+    }
+
+    public function testProcessThrowsExceptionForMissingTarget(): void
+    {
+        $tmp = sys_get_temp_dir() . '/factory_' . uniqid();
+        mkdir($tmp);
+        $cwd = getcwd();
+        chdir($tmp);
+
+        $composer = new Composer();
+        $dispatcher = new EventDispatcher($composer, new NullIO());
+        $composer->setEventDispatcher($dispatcher);
+        $package = new RootPackage('test/test', '1.0.0', '1.0.0');
+        $package->setExtra([
+            'somework/composer-symlinks' => [
+                'symlinks' => [
+                    'missing/file.txt' => 'link.txt'
+                ]
+            ]
+        ]);
+        $composer->setPackage($package);
+
+        $event = new Event('post-install-cmd', $composer, new NullIO());
+        $factory = new SymlinksFactory($event, new Filesystem());
+
+        $this->expectException(\SomeWork\Symlinks\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The target path  does not exists');
+
+        try {
+            $factory->process();
+        } finally {
+            chdir($cwd);
+        }
+    }
+
+    public function testProcessThrowsLinkDirectoryErrorOnEnsureDirectoryFailure(): void
+    {
+        $tmp = sys_get_temp_dir() . '/factory_' . uniqid();
+        mkdir($tmp);
+        mkdir($tmp . '/target');
+        file_put_contents($tmp . '/target/file.txt', 'content');
+        $cwd = getcwd();
+        chdir($tmp);
+
+        $composer = new Composer();
+        $dispatcher = new EventDispatcher($composer, new NullIO());
+        $composer->setEventDispatcher($dispatcher);
+        $package = new RootPackage('test/test', '1.0.0', '1.0.0');
+        $package->setExtra([
+            'somework/composer-symlinks' => [
+                'symlinks' => [
+                    'target/file.txt' => 'dir/link.txt'
+                ]
+            ]
+        ]);
+        $composer->setPackage($package);
+
+        $event = new Event('post-install-cmd', $composer, new NullIO());
+
+        $filesystem = $this->createMock(Filesystem::class);
+        $filesystem->method('isAbsolutePath')->willReturn(false);
+        $filesystem->expects($this->once())
+            ->method('ensureDirectoryExists')
+            ->willThrowException(new \RuntimeException('fail'));
+        $filesystem->expects($this->never())->method('relativeSymlink');
+
+        $factory = new SymlinksFactory($event, $filesystem);
+
+        $this->expectException(\SomeWork\Symlinks\LinkDirectoryError::class);
+
+        try {
+            $factory->process();
+        } finally {
+            chdir($cwd);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- ensure the factory rejects non-array `symlinks`
- add PHPUnit coverage for this case
- report code coverage via GitHub Actions

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68444ed5e0908320a65db1b4c0b6e40c