### PR TITLE
Add status command for auditing symlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,27 @@ $ composer symlinks:refresh --dry-run
 The legacy environment variable `SYMLINKS_DRY_RUN=1` is still honoured during
 Composer hooks for backwards compatibility.
 
-### 3. Execute composer
+### 3. Inspect symlink status
+
+Audit the current state of the configured links without modifying the
+filesystem:
+
+```bash
+$ composer symlinks:status
+```
+
+The command compares the configuration with the registry file and the actual
+filesystem. The report highlights missing links, mismatched targets, and stale
+entries that are present in the registry but no longer configured. Use the
+`--strict` option to make the command exit with a non-zero code when problems
+are detected (ideal for CI pipelines), and `--json` to obtain a machine-readable
+summary:
+
+```bash
+$ composer symlinks:status --json --strict
+```
+
+### 4. Execute composer
 
 DO NOT use --no-plugins for composer install or update
 
@@ -132,6 +152,9 @@ removed.
 | `Link ... already exists` | A file/directory already occupies the link path. |
 | `Cant unlink ...` | The plugin failed to remove a file when using `force-create`. |
 | `Failed to create symlink ... Enable Windows Developer Mode ...` | Windows denied symlink creation. Enable Developer Mode or set `windows-mode` to `junction`/`copy`. |
+
+Run `composer symlinks:status` after encountering an error to obtain a detailed
+report of which links are missing or pointing to unexpected targets.
 
 ### Windows compatibility
 

--- a/src/Symlinks/Command/CommandProvider.php
+++ b/src/Symlinks/Command/CommandProvider.php
@@ -11,6 +11,7 @@ class CommandProvider implements CommandProviderCapability
     {
         return [
             new RefreshCommand(),
+            new StatusCommand(),
         ];
     }
 }

--- a/src/Symlinks/Command/StatusCommand.php
+++ b/src/Symlinks/Command/StatusCommand.php
@@ -1,0 +1,264 @@
+<?php
+declare(strict_types=1);
+
+namespace SomeWork\Symlinks\Command;
+
+use Composer\Command\BaseCommand;
+use Composer\Script\Event;
+use Composer\Util\Filesystem;
+use SomeWork\Symlinks\SymlinksFactory;
+use SomeWork\Symlinks\SymlinksRegistry;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class StatusCommand extends BaseCommand
+{
+    private const STATUS_OK = 'ok';
+    private const STATUS_MISSING = 'missing';
+    private const STATUS_MISMATCH = 'mismatch';
+    private const STATUS_UNEXPECTED = 'unexpected';
+    private const STATUS_BROKEN = 'broken';
+    private const STATUS_STALE = 'stale';
+    private const STATUS_ORPHAN = 'orphan';
+
+    protected function configure(): void
+    {
+        $this
+            ->setName('symlinks:status')
+            ->setDescription('Show the current status of configured symlinks.')
+            ->addOption('json', null, InputOption::VALUE_NONE, 'Output the status information as JSON.')
+            ->addOption('strict', null, InputOption::VALUE_NONE, 'Return a non-zero exit code when problems are found.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $composer = $this->requireComposer();
+        $io = $this->getIO();
+
+        $filesystem = new Filesystem();
+        $event = new Event('symlinks:status', $composer, $io);
+        $factory = new SymlinksFactory($event, $filesystem);
+
+        try {
+            $factory->process();
+        } catch (\Throwable $exception) {
+            $io->writeError(sprintf('<error>Failed to read symlink configuration: %s</error>', $exception->getMessage()));
+
+            return Command::FAILURE;
+        }
+
+        $configuredSymlinks = $factory->getConfiguredSymlinks();
+        ksort($configuredSymlinks);
+
+        $registryData = [];
+        $vendorDir = $factory->getVendorDirPath();
+        if ($vendorDir !== null) {
+            $registry = new SymlinksRegistry($filesystem, $vendorDir);
+            $registryData = $registry->load();
+            ksort($registryData);
+        }
+
+        $report = [
+            'configured' => $this->buildConfiguredReport($configuredSymlinks, $filesystem),
+            'registry' => $this->buildRegistryReport($configuredSymlinks, $registryData, $filesystem),
+        ];
+
+        $hasProblems = $this->hasProblems($report);
+
+        if ($input->getOption('json')) {
+            $io->write(json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+            return $hasProblems && $input->getOption('strict') ? Command::FAILURE : Command::SUCCESS;
+        }
+
+        $this->renderReport($report, $io);
+
+        if ($hasProblems) {
+            $io->writeError('<error>Problems were found while checking symlinks.</error>');
+
+            if ($input->getOption('strict')) {
+                return Command::FAILURE;
+            }
+        } else {
+            $io->write('<info>No issues detected.</info>');
+        }
+
+        return Command::SUCCESS;
+    }
+
+    private function buildConfiguredReport(array $configuredSymlinks, Filesystem $filesystem): array
+    {
+        $report = [];
+
+        foreach ($configuredSymlinks as $link => $target) {
+            [$actual, $type] = $this->inspectPath($link, $filesystem);
+            $status = self::STATUS_OK;
+
+            if ($type === 'missing') {
+                $status = self::STATUS_MISSING;
+            } elseif ($type === 'file') {
+                $status = self::STATUS_UNEXPECTED;
+            } elseif ($type === 'symlink-broken') {
+                $status = self::STATUS_BROKEN;
+            } elseif ($type === 'symlink') {
+                if ($actual === null || $this->normalizePath($actual) !== $this->normalizePath($target)) {
+                    $status = self::STATUS_MISMATCH;
+                }
+            }
+
+            $report[] = [
+                'link' => $link,
+                'expected' => $target,
+                'actual' => $actual,
+                'status' => $status,
+                'type' => 'configured',
+            ];
+        }
+
+        return $report;
+    }
+
+    private function buildRegistryReport(array $configuredSymlinks, array $registryData, Filesystem $filesystem): array
+    {
+        $report = [];
+
+        foreach ($registryData as $link => $target) {
+            if (isset($configuredSymlinks[$link])) {
+                continue;
+            }
+
+            [$actual, $type] = $this->inspectPath($link, $filesystem);
+            $status = self::STATUS_ORPHAN;
+
+            if ($type === 'missing') {
+                $status = self::STATUS_STALE;
+            } elseif ($type === 'symlink-broken') {
+                $status = self::STATUS_BROKEN;
+            }
+
+            $report[] = [
+                'link' => $link,
+                'expected' => $target,
+                'actual' => $actual,
+                'status' => $status,
+                'type' => 'registry',
+            ];
+        }
+
+        return $report;
+    }
+
+    private function inspectPath(string $link, Filesystem $filesystem): array
+    {
+        if (is_link($link)) {
+            $target = @readlink($link);
+            if ($target === false) {
+                return [null, 'symlink-broken'];
+            }
+
+            if ($filesystem->isAbsolutePath($target)) {
+                $resolved = realpath($target);
+                if ($resolved === false) {
+                    $resolved = $target;
+                }
+            } else {
+                $base = realpath(dirname($link));
+                if ($base === false) {
+                    $base = dirname($link);
+                }
+
+                $combined = $base . DIRECTORY_SEPARATOR . $target;
+                $resolved = realpath($combined);
+                if ($resolved === false) {
+                    $resolved = $combined;
+                }
+            }
+
+            return [$resolved, 'symlink'];
+        }
+
+        if (file_exists($link)) {
+            $resolved = realpath($link);
+            if ($resolved === false) {
+                $resolved = $link;
+            }
+
+            return [$resolved, 'file'];
+        }
+
+        return [null, 'missing'];
+    }
+
+    private function normalizePath(?string $path): ?string
+    {
+        if ($path === null) {
+            return null;
+        }
+
+        if (DIRECTORY_SEPARATOR === '\\') {
+            return strtolower(str_replace('\\', '/', $path));
+        }
+
+        return $path;
+    }
+
+    private function hasProblems(array $report): bool
+    {
+        foreach ($report['configured'] ?? [] as $item) {
+            if ($item['status'] !== self::STATUS_OK) {
+                return true;
+            }
+        }
+
+        foreach ($report['registry'] ?? [] as $item) {
+            if ($item['status'] !== self::STATUS_OK) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function renderReport(array $report, \Composer\IO\IOInterface $io): void
+    {
+        $io->write('<info>Configured symlinks</info>');
+        if ($report['configured'] === []) {
+            $io->write('  (none)');
+        } else {
+            foreach ($report['configured'] as $item) {
+                $io->write($this->formatLine($item));
+            }
+        }
+
+        if ($report['registry'] !== []) {
+            $io->write('<info>Registry entries</info>');
+            foreach ($report['registry'] as $item) {
+                $io->write($this->formatLine($item));
+            }
+        }
+    }
+
+    private function formatLine(array $item): string
+    {
+        $status = strtoupper((string) $item['status']);
+        $line = sprintf('  [%s] %s -> %s', $status, $item['link'], $item['expected']);
+
+        if ($item['actual'] !== null && $this->normalizePath($item['actual']) !== $this->normalizePath($item['expected'])) {
+            $line .= sprintf(' (actual: %s)', $item['actual']);
+        }
+
+        if ($item['status'] === self::STATUS_MISSING) {
+            $line .= ' (missing)';
+        } elseif ($item['status'] === self::STATUS_BROKEN) {
+            $line .= ' (broken link)';
+        }
+
+        if ($item['type'] === 'registry') {
+            $line .= ' [registry]';
+        }
+
+        return $line;
+    }
+}

--- a/tests/StatusCommandTest.php
+++ b/tests/StatusCommandTest.php
@@ -1,0 +1,248 @@
+<?php
+
+namespace SomeWork\Symlinks\Tests;
+
+use Composer\Composer;
+use Composer\Console\Application;
+use Composer\EventDispatcher\EventDispatcher;
+use Composer\IO\IOInterface;
+use Composer\IO\NullIO;
+use Composer\Package\RootPackage;
+use PHPUnit\Framework\TestCase;
+use SomeWork\Symlinks\Command\StatusCommand;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class StatusCommandTest extends TestCase
+{
+    public function testStatusCommandOutputsReport(): void
+    {
+        $environment = $this->createEnvironment();
+        $composer = $this->createComposer($environment['extra'], $environment['vendorDir']);
+
+        $io = $this->createIoSpy();
+        $tester = $this->createCommandTester($composer, $io['mock']);
+
+        $cwd = getcwd();
+        chdir($environment['projectDir']);
+
+        try {
+            $exitCode = $tester->execute(['command' => 'symlinks:status']);
+        } finally {
+            chdir($cwd);
+            $this->removeDirectory($environment['projectDir']);
+        }
+
+        $this->assertSame(0, $exitCode);
+
+        $output = implode("\n", $io['output']);
+        $errors = implode("\n", $io['errors']);
+
+        $this->assertStringContainsString('Configured symlinks', $output);
+        $this->assertStringContainsString('[OK]', $output);
+        $this->assertStringContainsString('[MISSING]', $output);
+        $this->assertStringContainsString('[MISMATCH]', $output);
+        $this->assertStringContainsString('Registry entries', $output);
+        $this->assertStringContainsString('[STALE]', $output);
+        $this->assertStringContainsString('[ORPHAN]', $output);
+        $this->assertStringContainsString('Problems were found while checking symlinks.', $errors);
+    }
+
+    public function testStatusCommandOutputsJson(): void
+    {
+        $environment = $this->createEnvironment();
+        $composer = $this->createComposer($environment['extra'], $environment['vendorDir']);
+
+        $io = $this->createIoSpy();
+        $tester = $this->createCommandTester($composer, $io['mock']);
+
+        $cwd = getcwd();
+        chdir($environment['projectDir']);
+
+        try {
+            $exitCode = $tester->execute([
+                'command' => 'symlinks:status',
+                '--json' => true,
+            ]);
+        } finally {
+            chdir($cwd);
+            $this->removeDirectory($environment['projectDir']);
+        }
+
+        $this->assertSame(0, $exitCode);
+
+        $this->assertCount(1, $io['output']);
+        $decoded = json_decode($io['output'][0], true);
+
+        $this->assertIsArray($decoded);
+        $this->assertArrayHasKey('configured', $decoded);
+        $this->assertArrayHasKey('registry', $decoded);
+
+        $statuses = array_column($decoded['configured'], 'status');
+        $this->assertContains('ok', $statuses);
+        $this->assertContains('missing', $statuses);
+        $this->assertContains('mismatch', $statuses);
+
+        $registryStatuses = array_column($decoded['registry'], 'status');
+        $this->assertContains('stale', $registryStatuses);
+        $this->assertContains('orphan', $registryStatuses);
+
+        $this->assertSame([], $io['errors']);
+    }
+
+    public function testStrictOptionReturnsFailure(): void
+    {
+        $environment = $this->createEnvironment();
+        $composer = $this->createComposer($environment['extra'], $environment['vendorDir']);
+
+        $io = $this->createIoSpy();
+        $tester = $this->createCommandTester($composer, $io['mock']);
+
+        $cwd = getcwd();
+        chdir($environment['projectDir']);
+
+        try {
+            $exitCode = $tester->execute([
+                'command' => 'symlinks:status',
+                '--strict' => true,
+            ]);
+        } finally {
+            chdir($cwd);
+            $this->removeDirectory($environment['projectDir']);
+        }
+
+        $this->assertSame(1, $exitCode);
+    }
+
+    /**
+     * @return array{projectDir: string, vendorDir: string, extra: array}
+     */
+    private function createEnvironment(): array
+    {
+        $projectDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'status_' . uniqid('', true);
+        $sourceDir = $projectDir . DIRECTORY_SEPARATOR . 'source';
+        $vendorDir = $projectDir . DIRECTORY_SEPARATOR . 'vendor';
+
+        mkdir($sourceDir, 0777, true);
+        mkdir($vendorDir, 0777, true);
+
+        file_put_contents($sourceDir . DIRECTORY_SEPARATOR . 'ok.txt', 'ok');
+        file_put_contents($sourceDir . DIRECTORY_SEPARATOR . 'missing.txt', 'missing');
+        file_put_contents($sourceDir . DIRECTORY_SEPARATOR . 'other.txt', 'other');
+
+        symlink($sourceDir . DIRECTORY_SEPARATOR . 'ok.txt', $projectDir . DIRECTORY_SEPARATOR . 'link-ok.txt');
+        symlink($sourceDir . DIRECTORY_SEPARATOR . 'ok.txt', $projectDir . DIRECTORY_SEPARATOR . 'link-mismatch.txt');
+        symlink($sourceDir . DIRECTORY_SEPARATOR . 'ok.txt', $projectDir . DIRECTORY_SEPARATOR . 'registry-orphan.txt');
+
+        $registryData = [
+            $projectDir . DIRECTORY_SEPARATOR . 'registry-stale.txt' => realpath($sourceDir . DIRECTORY_SEPARATOR . 'ok.txt'),
+            $projectDir . DIRECTORY_SEPARATOR . 'registry-orphan.txt' => realpath($sourceDir . DIRECTORY_SEPARATOR . 'ok.txt'),
+        ];
+
+        file_put_contents(
+            $vendorDir . DIRECTORY_SEPARATOR . 'composer-symlinks-state.json',
+            json_encode($registryData, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
+        );
+
+        $extra = [
+            'somework/composer-symlinks' => [
+                'symlinks' => [
+                    'source/ok.txt' => 'link-ok.txt',
+                    'source/missing.txt' => 'link-missing.txt',
+                    'source/other.txt' => 'link-mismatch.txt',
+                ],
+            ],
+        ];
+
+        return [
+            'projectDir' => $projectDir,
+            'vendorDir' => $vendorDir,
+            'extra' => $extra,
+        ];
+    }
+
+    private function createComposer(array $extra, string $vendorDir): Composer
+    {
+        $composer = new Composer();
+        $io = new NullIO();
+        $dispatcher = new EventDispatcher($composer, $io);
+        $composer->setEventDispatcher($dispatcher);
+
+        $package = new RootPackage('test/test', '1.0.0', '1.0.0');
+        $package->setExtra($extra);
+        $composer->setPackage($package);
+
+        $config = new \Composer\Config();
+        $config->merge(['config' => ['vendor-dir' => $vendorDir]]);
+        $composer->setConfig($config);
+
+        return $composer;
+    }
+
+    /**
+     * @return array{mock: IOInterface, output: array<int, string>, errors: array<int, string>}
+     */
+    private function createIoSpy(): array
+    {
+        $output = [];
+        $errors = [];
+
+        $io = $this->createMock(IOInterface::class);
+        $io->method('write')->willReturnCallback(function ($messages, $newline = true, $verbosity = IOInterface::NORMAL) use (&$output): void {
+            $messages = is_array($messages) ? $messages : [$messages];
+            foreach ($messages as $message) {
+                $output[] = $message;
+            }
+        });
+        $io->method('writeError')->willReturnCallback(function ($messages, $newline = true, $verbosity = IOInterface::NORMAL) use (&$errors): void {
+            $messages = is_array($messages) ? $messages : [$messages];
+            foreach ($messages as $message) {
+                $errors[] = $message;
+            }
+        });
+        $io->method('isDecorated')->willReturn(false);
+        $io->method('isVerbose')->willReturn(false);
+        $io->method('isVeryVerbose')->willReturn(false);
+        $io->method('isDebug')->willReturn(false);
+
+        return [
+            'mock' => $io,
+            'output' => &$output,
+            'errors' => &$errors,
+        ];
+    }
+
+    private function createCommandTester(Composer $composer, IOInterface $io): CommandTester
+    {
+        $command = new StatusCommand();
+        $command->setComposer($composer);
+        $command->setIO($io);
+
+        $application = new Application();
+        $application->setAutoExit(false);
+        $application->add($command);
+
+        return new CommandTester($application->find('symlinks:status'));
+    }
+
+    private function removeDirectory(string $directory): void
+    {
+        if (!is_dir($directory)) {
+            return;
+        }
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($directory, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($iterator as $item) {
+            if ($item->isLink() || $item->isFile()) {
+                @unlink($item->getPathname());
+            } elseif ($item->isDir()) {
+                @rmdir($item->getPathname());
+            }
+        }
+
+        @rmdir($directory);
+    }
+}


### PR DESCRIPTION
## Summary
- add a `symlinks:status` console command that audits configured links with optional JSON and strict modes
- register the new command with the Composer plugin and document usage and troubleshooting guidance in the README
- cover the command with unit tests that exercise human-readable, JSON, and strict behaviours

## Testing
- ./vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68d628400c008320a69a1559707eb973